### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SoundCloud Java library [![Build Status](https://travis-ci.org/nok/soundcloud-java-library.svg?branch=dev)](https://travis-ci.org/nok/soundcloud-java-library)
+# SoundCloud Java library [![Build Status](https://travis-ci.org/nok/soundcloud-java-library.svg?branch=dev)](https://travis-ci.org/nok/soundcloud-java-library) [![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Soundcloud/functions?utm_source=SoundcloudGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 Unofficial Java library, which simplifies the use of the official [SoundCloud Java API wrapper](https://github.com/soundcloud/java-api-wrapper).
 


### PR DESCRIPTION
Hey there. I added a link to the README for a tool where you can test out the Soundcloud API calls in your browser. It's pretty cool because you can export the code snippet into multiple languages as well. I thought it would be useful because I've seen it on other SDKs (Telegram, Shopify and LinkedIn). Full disclosure--I do work on the team that built this tool, but honestly, people seem to find it useful for this kind of stuff.